### PR TITLE
Add dashboard views for front desk and doctor

### DIFF
--- a/src/components/dashboard/DoctorView.tsx
+++ b/src/components/dashboard/DoctorView.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import ConsultationPanel from "./ConsultationPanel";
+import PatientHistory from "./PatientHistory";
+
+interface Patient {
+  name: string;
+  age: number;
+  gender: string;
+  visitReason: string;
+}
+
+interface DoctorViewProps {
+  currentPatient: Patient;
+}
+
+const DoctorView = ({ currentPatient }: DoctorViewProps) => {
+  return (
+    <div className="flex h-full w-full">
+      <div className="flex-1 overflow-y-auto">
+        <ConsultationPanel
+          patientName={currentPatient.name}
+          patientAge={currentPatient.age}
+          patientGender={currentPatient.gender}
+          currentVisitReason={currentPatient.visitReason}
+        />
+      </div>
+      <div className="w-[350px] border-l bg-gray-50 p-4 overflow-y-auto">
+        <PatientHistory patientName={currentPatient.name} />
+      </div>
+    </div>
+  );
+};
+
+export default DoctorView;
+

--- a/src/components/dashboard/FrontDeskView.tsx
+++ b/src/components/dashboard/FrontDeskView.tsx
@@ -1,0 +1,31 @@
+import React from "react";
+import PatientRegistration from "./PatientRegistration";
+import AppointmentCalendar from "./AppointmentCalendar";
+import PatientQueue from "./PatientQueue";
+
+interface FrontDeskViewProps {
+  onPatientRegistration?: (data: any) => void;
+  onAppointmentSchedule?: (data: any) => void;
+  onQueueUpdate?: (data: any) => void;
+}
+
+const FrontDeskView = ({
+  onPatientRegistration = () => {},
+  onAppointmentSchedule = () => {},
+  onQueueUpdate = () => {},
+}: FrontDeskViewProps) => {
+  return (
+    <div className="flex h-full w-full">
+      <div className="flex-1 overflow-y-auto">
+        <PatientRegistration onSubmit={onPatientRegistration} />
+      </div>
+      <div className="w-[350px] border-l bg-gray-50 p-4 flex flex-col gap-4 overflow-y-auto">
+        <AppointmentCalendar onAddAppointment={onAppointmentSchedule} />
+        <PatientQueue />
+      </div>
+    </div>
+  );
+};
+
+export default FrontDeskView;
+


### PR DESCRIPTION
## Summary
- implement `FrontDeskView` component with patient registration, appointment scheduling and queue sections
- add `DoctorView` component showing consultation panel and patient history for current patient

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68909ef6bd2083268a8617c5a64452d5