### PR TITLE
feat: realtime patient queue and check-in

### DIFF
--- a/src/components/dashboard/ConsultationPanel.tsx
+++ b/src/components/dashboard/ConsultationPanel.tsx
@@ -10,10 +10,12 @@ import { Separator } from "@/components/ui/separator";
 import { Clock, FileText, Stethoscope, Pill, Save } from "lucide-react";
 
 interface ConsultationPanelProps {
+  patientId?: string;
   patientName?: string;
   patientAge?: number;
   patientGender?: string;
   currentVisitReason?: string;
+  onComplete?: () => void;
 }
 
 const ConsultationPanel = ({
@@ -21,6 +23,7 @@ const ConsultationPanel = ({
   patientAge = 45,
   patientGender = "Male",
   currentVisitReason = "Regular checkup",
+  onComplete,
 }: ConsultationPanelProps) => {
   return (
     <div className="h-full w-full bg-white p-4">
@@ -152,7 +155,7 @@ const ConsultationPanel = ({
 
           <div className="flex justify-end mt-6 gap-4">
             <Button variant="outline">Cancel</Button>
-            <Button>
+            <Button onClick={onComplete}>
               <Save className="h-4 w-4 mr-2" />
               Save Consultation
             </Button>

--- a/src/components/dashboard/DoctorView.tsx
+++ b/src/components/dashboard/DoctorView.tsx
@@ -1,31 +1,52 @@
-import React from "react";
+import React, { useState } from "react";
 import ConsultationPanel from "./ConsultationPanel";
 import PatientHistory from "./PatientHistory";
+import PatientQueue from "./PatientQueue";
 
 interface Patient {
+  id: string;
   name: string;
   age: number;
   gender: string;
   visitReason: string;
+  status: "waiting" | "in-consultation" | "completed";
 }
 
-interface DoctorViewProps {
-  currentPatient: Patient;
-}
+const DoctorView = () => {
+  const [currentPatient, setCurrentPatient] = useState<Patient | null>(null);
 
-const DoctorView = ({ currentPatient }: DoctorViewProps) => {
+  const handleCheckIn = (patient: Patient) => {
+    setCurrentPatient(patient);
+  };
+
+  const handleComplete = async (id: string) => {
+    await fetch(`/api/queue/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ status: "completed" }),
+    }).catch((err) => console.error("Failed to complete consultation", err));
+    setCurrentPatient(null);
+  };
+
   return (
     <div className="flex h-full w-full">
+      <div className="w-[350px] border-r bg-gray-50 p-4 overflow-y-auto">
+        <PatientQueue onCheckIn={handleCheckIn} />
+      </div>
       <div className="flex-1 overflow-y-auto">
-        <ConsultationPanel
-          patientName={currentPatient.name}
-          patientAge={currentPatient.age}
-          patientGender={currentPatient.gender}
-          currentVisitReason={currentPatient.visitReason}
-        />
+        {currentPatient && (
+          <ConsultationPanel
+            patientId={currentPatient.id}
+            patientName={currentPatient.name}
+            patientAge={currentPatient.age}
+            patientGender={currentPatient.gender}
+            currentVisitReason={currentPatient.visitReason}
+            onComplete={() => handleComplete(currentPatient.id)}
+          />
+        )}
       </div>
       <div className="w-[350px] border-l bg-gray-50 p-4 overflow-y-auto">
-        <PatientHistory patientName={currentPatient.name} />
+        {currentPatient && <PatientHistory patientName={currentPatient.name} />}
       </div>
     </div>
   );

--- a/src/components/home.tsx
+++ b/src/components/home.tsx
@@ -53,14 +53,7 @@ const Home = ({
             onQueueUpdate={(data) => console.log("Queue updated:", data)}
           />
         ) : (
-          <DoctorView
-            currentPatient={{
-              name: "John Doe",
-              age: 45,
-              gender: "Male",
-              visitReason: "Regular checkup",
-            }}
-          />
+          <DoctorView />
         )}
       </main>
     </div>


### PR DESCRIPTION
## Summary
- load patients from `/api/queue` with realtime updates
- allow doctors to check in patients and finish consultations
- integrate patient queue into doctor workflow

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: TS2345, TS2322, TS2339)*

------
https://chatgpt.com/codex/tasks/task_e_6890f6fe80588326826ca08efbf3a2c0