### PR TITLE
Add role-protected dashboard views with navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,19 @@
 import { Suspense } from "react";
-import { useRoutes, Routes, Route } from "react-router-dom";
+import { useRoutes, Routes, Route, Navigate } from "react-router-dom";
 import Home from "./components/home";
 import LandingPage from "./components/landing/LandingPage";
 import Login from "./pages/Login";
 import Signup from "./pages/Signup";
 import ProtectedRoute from "./components/auth/ProtectedRoute";
+import { useAuth } from "./lib/auth";
 import routes from "tempo-routes";
+
+function DashboardRedirect() {
+  const { user } = useAuth();
+  const role = (user?.user_metadata as { role?: string } | undefined)?.role;
+  if (role === "front-desk") return <Navigate to="/front-desk" replace />;
+  return <Navigate to="/doctor" replace />;
+}
 
 function App() {
   return (
@@ -16,10 +24,26 @@ function App() {
           <Route path="/login" element={<Login />} />
           <Route path="/signup" element={<Signup />} />
           <Route
+            path="/doctor"
+            element={
+              <ProtectedRoute roles={["doctor"]}>
+                <Home role="doctor" />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/front-desk"
+            element={
+              <ProtectedRoute roles={["front-desk"]}>
+                <Home role="front-desk" />
+              </ProtectedRoute>
+            }
+          />
+          <Route
             path="/dashboard"
             element={
               <ProtectedRoute>
-                <Home />
+                <DashboardRedirect />
               </ProtectedRoute>
             }
           />

--- a/src/components/DashboardHeader.tsx
+++ b/src/components/DashboardHeader.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useNavigate } from "react-router-dom";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -32,6 +33,14 @@ const DashboardHeader = ({
   onRoleSwitch = () => {},
   onLogout = () => {},
 }: DashboardHeaderProps) => {
+  const navigate = useNavigate();
+
+  const handleRoleSwitch = () => {
+    const target = userRole === "doctor" ? "/front-desk" : "/doctor";
+    navigate(target);
+    onRoleSwitch(userRole === "doctor" ? "front-desk" : "doctor");
+  };
+
   return (
     <header className="w-full h-16 bg-white border-b px-4 flex items-center justify-between">
       <div className="flex items-center space-x-4">
@@ -47,28 +56,38 @@ const DashboardHeader = ({
         <nav className="hidden md:flex items-center space-x-2">
           {userRole === "front-desk" ? (
             <>
-              <Button variant="ghost" className="flex items-center space-x-2">
-                <Calendar className="h-4 w-4" />
-                <span>Appointments</span>
+              <Button variant="ghost" asChild>
+                <a href="#appointments" className="flex items-center space-x-2">
+                  <Calendar className="h-4 w-4" />
+                  <span>Appointments</span>
+                </a>
               </Button>
-              <Button variant="ghost" className="flex items-center space-x-2">
-                <UserPlus className="h-4 w-4" />
-                <span>Register Patient</span>
+              <Button variant="ghost" asChild>
+                <a href="#register" className="flex items-center space-x-2">
+                  <UserPlus className="h-4 w-4" />
+                  <span>Register Patient</span>
+                </a>
               </Button>
-              <Button variant="ghost" className="flex items-center space-x-2">
-                <Users className="h-4 w-4" />
-                <span>Patient Queue</span>
+              <Button variant="ghost" asChild>
+                <a href="#queue" className="flex items-center space-x-2">
+                  <Users className="h-4 w-4" />
+                  <span>Patient Queue</span>
+                </a>
               </Button>
             </>
           ) : (
             <>
-              <Button variant="ghost" className="flex items-center space-x-2">
-                <Users className="h-4 w-4" />
-                <span>My Patients</span>
+              <Button variant="ghost" asChild>
+                <a href="#queue" className="flex items-center space-x-2">
+                  <Users className="h-4 w-4" />
+                  <span>My Patients</span>
+                </a>
               </Button>
-              <Button variant="ghost" className="flex items-center space-x-2">
-                <Calendar className="h-4 w-4" />
-                <span>Schedule</span>
+              <Button variant="ghost" asChild>
+                <a href="#appointments" className="flex items-center space-x-2">
+                  <Calendar className="h-4 w-4" />
+                  <span>Schedule</span>
+                </a>
               </Button>
             </>
           )}
@@ -87,11 +106,7 @@ const DashboardHeader = ({
               <User className="mr-2 h-4 w-4" />
               <span>{userName}</span>
             </DropdownMenuItem>
-            <DropdownMenuItem
-              onClick={() =>
-                onRoleSwitch(userRole === "doctor" ? "front-desk" : "doctor")
-              }
-            >
+            <DropdownMenuItem onClick={handleRoleSwitch}>
               <Users className="mr-2 h-4 w-4" />
               <span>
                 Switch to {userRole === "doctor" ? "Front Desk" : "Doctor"} View

--- a/src/components/auth/ProtectedRoute.tsx
+++ b/src/components/auth/ProtectedRoute.tsx
@@ -2,10 +2,21 @@ import { ReactNode } from "react";
 import { Navigate } from "react-router-dom";
 import { useAuth } from "@/lib/auth";
 
-export default function ProtectedRoute({ children }: { children: ReactNode }) {
+interface ProtectedRouteProps {
+  children: ReactNode;
+  roles?: Array<"doctor" | "front-desk">;
+}
+
+export default function ProtectedRoute({ children, roles }: ProtectedRouteProps) {
   const { user } = useAuth();
   if (!user) {
     return <Navigate to="/login" replace />;
   }
+
+  const userRole = (user.user_metadata as { role?: string } | undefined)?.role;
+  if (roles && !roles.includes(userRole as any)) {
+    return <Navigate to="/login" replace />;
+  }
+
   return <>{children}</>;
 }

--- a/src/components/dashboard/AppointmentCalendar.tsx
+++ b/src/components/dashboard/AppointmentCalendar.tsx
@@ -32,6 +32,7 @@ import {
   Appointment,
 } from "@/lib/appointments";
 import { supabase } from "@/lib/supabase";
+import { useAuth } from "@/lib/auth";
 
 const locales = {
   "en-US": enUS,
@@ -71,6 +72,7 @@ const toCalendarEvent = (a: Appointment): CalendarEvent => ({
 });
 
 const AppointmentCalendar: React.FC = () => {
+  const { user } = useAuth();
   const [events, setEvents] = useState<CalendarEvent[]>([]);
   const [patients, setPatients] = useState<{ id: string; full_name: string }[]>([]);
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -123,6 +125,7 @@ const AppointmentCalendar: React.FC = () => {
   const handleSave = async () => {
     const payload = {
       patient_id: form.patient_id,
+      doctor_id: user?.id ?? null,
       department: form.department,
       start_time: form.start.toISOString(),
       end_time: form.end.toISOString(),

--- a/src/components/dashboard/DoctorView.tsx
+++ b/src/components/dashboard/DoctorView.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import ConsultationPanel from "./ConsultationPanel";
 import PatientHistory from "./PatientHistory";
 import PatientQueue from "./PatientQueue";
+import UpcomingAppointments from "./UpcomingAppointments";
 
 interface Patient {
   id: string;
@@ -29,11 +30,14 @@ const DoctorView = () => {
   };
 
   return (
-    <div className="flex h-full w-full">
-      <div className="w-[350px] border-r bg-gray-50 p-4 overflow-y-auto">
-        <PatientQueue onCheckIn={handleCheckIn} />
+    <div className="flex flex-col md:flex-row h-full w-full">
+      <div className="w-full md:w-[350px] border-b md:border-b-0 md:border-r bg-gray-50 p-4 overflow-y-auto space-y-4 order-2 md:order-1">
+        <UpcomingAppointments />
+        <div id="queue">
+          <PatientQueue onCheckIn={handleCheckIn} />
+        </div>
       </div>
-      <div className="flex-1 overflow-y-auto">
+      <div className="flex-1 overflow-y-auto order-1 md:order-2">
         {currentPatient && (
           <ConsultationPanel
             patientId={currentPatient.id}
@@ -45,7 +49,7 @@ const DoctorView = () => {
           />
         )}
       </div>
-      <div className="w-[350px] border-l bg-gray-50 p-4 overflow-y-auto">
+      <div className="w-full md:w-[350px] border-t md:border-t-0 md:border-l bg-gray-50 p-4 overflow-y-auto order-3">
         {currentPatient && <PatientHistory patientName={currentPatient.name} />}
       </div>
     </div>

--- a/src/components/dashboard/FrontDeskView.tsx
+++ b/src/components/dashboard/FrontDeskView.tsx
@@ -5,23 +5,27 @@ import PatientQueue from "./PatientQueue";
 
 interface FrontDeskViewProps {
   onPatientRegistration?: (data: any) => void;
-  onAppointmentSchedule?: (data: any) => void;
   onQueueUpdate?: (data: any) => void;
 }
 
 const FrontDeskView = ({
   onPatientRegistration = () => {},
-  onAppointmentSchedule = () => {},
   onQueueUpdate = () => {},
 }: FrontDeskViewProps) => {
   return (
-    <div className="flex h-full w-full">
-      <div className="flex-1 overflow-y-auto">
-        <PatientRegistration onSubmit={onPatientRegistration} />
+    <div className="flex flex-col md:flex-row h-full w-full">
+      <div className="flex-1 overflow-y-auto p-4 order-2 md:order-1">
+        <div id="register">
+          <PatientRegistration onSubmit={onPatientRegistration} />
+        </div>
       </div>
-      <div className="w-[350px] border-l bg-gray-50 p-4 flex flex-col gap-4 overflow-y-auto">
-        <AppointmentCalendar onAddAppointment={onAppointmentSchedule} />
-        <PatientQueue />
+      <div className="w-full md:w-[350px] border-t md:border-t-0 md:border-l bg-gray-50 p-4 flex flex-col gap-4 overflow-y-auto order-1 md:order-2">
+        <div id="appointments">
+          <AppointmentCalendar />
+        </div>
+        <div id="queue">
+          <PatientQueue />
+        </div>
       </div>
     </div>
   );

--- a/src/components/dashboard/UpcomingAppointments.tsx
+++ b/src/components/dashboard/UpcomingAppointments.tsx
@@ -1,0 +1,52 @@
+import React, { useEffect, useState } from "react";
+import { Card } from "@/components/ui/card";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { useAuth } from "@/lib/auth";
+import { fetchAppointments, Appointment } from "@/lib/appointments";
+import { format } from "date-fns";
+
+const UpcomingAppointments: React.FC = () => {
+  const { user } = useAuth();
+  const [appointments, setAppointments] = useState<Appointment[]>([]);
+
+  useEffect(() => {
+    const load = async () => {
+      const all = await fetchAppointments();
+      const upcoming = all
+        .filter(
+          (a) =>
+            a.doctor_id === user?.id && new Date(a.start_time) > new Date(),
+        )
+        .sort(
+          (a, b) =>
+            new Date(a.start_time).getTime() - new Date(b.start_time).getTime(),
+        )
+        .slice(0, 5);
+      setAppointments(upcoming);
+    };
+    if (user) {
+      load();
+    }
+  }, [user]);
+
+  return (
+    <Card className="w-full bg-white p-4" id="appointments">
+      <h2 className="text-xl font-semibold mb-4">Upcoming Appointments</h2>
+      <ScrollArea className="h-60">
+        <ul className="space-y-2">
+          {appointments.map((a) => (
+            <li key={a.id} className="flex justify-between text-sm">
+              <span>{a.patient_name}</span>
+              <span>{format(new Date(a.start_time), "PP p")}</span>
+            </li>
+          ))}
+          {appointments.length === 0 && (
+            <p className="text-sm text-gray-500">No upcoming appointments</p>
+          )}
+        </ul>
+      </ScrollArea>
+    </Card>
+  );
+};
+
+export default UpcomingAppointments;

--- a/src/components/home.tsx
+++ b/src/components/home.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "@/lib/auth";
 import DashboardHeader from "./DashboardHeader";
@@ -6,24 +6,16 @@ import FrontDeskView from "./dashboard/FrontDeskView";
 import DoctorView from "./dashboard/DoctorView";
 
 interface HomeProps {
-  initialRole?: "doctor" | "front-desk";
+  role: "doctor" | "front-desk";
   userName?: string;
   userAvatar?: string;
 }
 
 const Home = ({
-  initialRole = "doctor",
+  role,
   userName = "Dr. John Doe",
   userAvatar = "https://api.dicebear.com/7.x/avataaars/svg?seed=doctor",
 }: HomeProps) => {
-  const [currentRole, setCurrentRole] = useState<"doctor" | "front-desk">(
-    initialRole,
-  );
-
-  const handleRoleSwitch = (newRole: "doctor" | "front-desk") => {
-    setCurrentRole(newRole);
-  };
-
   const { signOut } = useAuth();
   const navigate = useNavigate();
 
@@ -32,29 +24,30 @@ const Home = ({
     navigate("/");
   };
 
+  const handleRoleSwitch = (newRole: "doctor" | "front-desk") => {
+    navigate(newRole === "doctor" ? "/doctor" : "/front-desk");
+  };
+
   return (
     <div className="min-h-screen flex flex-col bg-gray-100">
       <DashboardHeader
         userName={userName}
-        userRole={currentRole}
+        userRole={role}
         userAvatar={userAvatar}
         onRoleSwitch={handleRoleSwitch}
         onLogout={handleLogout}
       />
       <main className="flex-1 h-[calc(100vh-64px)]">
-        {currentRole === "front-desk" ? (
-          <FrontDeskView
-            onPatientRegistration={(data) =>
-              console.log("Patient registration:", data)
-            }
-            onAppointmentSchedule={(data) =>
-              console.log("Appointment scheduled:", data)
-            }
-            onQueueUpdate={(data) => console.log("Queue updated:", data)}
-          />
-        ) : (
-          <DoctorView />
-        )}
+          {role === "front-desk" ? (
+            <FrontDeskView
+              onPatientRegistration={(data) =>
+                console.log("Patient registration:", data)
+              }
+              onQueueUpdate={(data) => console.log("Queue updated:", data)}
+            />
+          ) : (
+            <DoctorView />
+          )}
       </main>
     </div>
   );

--- a/src/lib/appointments.ts
+++ b/src/lib/appointments.ts
@@ -52,7 +52,7 @@ export async function createAppointment(
     start_time: data.start_time,
     end_time: data.end_time,
     status: data.status,
-    patient_name: data.patients?.full_name ?? "",
+      patient_name: (data as any).patients?.full_name ?? "",
   };
 }
 
@@ -77,7 +77,7 @@ export async function updateAppointment(
     start_time: data.start_time,
     end_time: data.end_time,
     status: data.status,
-    patient_name: data.patients?.full_name ?? "",
+      patient_name: (data as any).patients?.full_name ?? "",
   };
 }
 


### PR DESCRIPTION
## Summary
- Implement role-aware routing with protected doctor and front desk dashboards
- Add dashboard header navigation and role switching
- Introduce responsive doctor and front desk views with upcoming appointments and queue widgets

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890f871cd2c8326a93dd2fc89e8d31a