### PR TITLE
Add patient encounter history with secure API

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -1,0 +1,12 @@
+import express from "express";
+import patientHistory from "./patient-history";
+
+const app = express();
+
+app.use(express.json());
+app.use("/api/patient-history", patientHistory);
+
+const port = process.env.PORT || 3001;
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});

--- a/server/patient-history.ts
+++ b/server/patient-history.ts
@@ -1,0 +1,90 @@
+import express from "express";
+import { createClient } from "@supabase/supabase-js";
+
+const router = express.Router();
+
+const supabaseUrl = process.env.SUPABASE_URL || "";
+const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || "";
+const supabase = createClient(supabaseUrl, supabaseServiceKey);
+
+async function ensureStaff(req: express.Request, res: express.Response) {
+  const authHeader = req.headers.authorization;
+  const token = authHeader?.split(" ")[1];
+  if (!token) {
+    res.status(401).json({ error: "Unauthorized" });
+    return null;
+  }
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser(token);
+  if (error || !user || user.user_metadata?.role !== "staff") {
+    res.status(403).json({ error: "Forbidden" });
+    return null;
+  }
+  return user;
+}
+
+router.get("/:patientId", async (req, res) => {
+  const user = await ensureStaff(req, res);
+  if (!user) return;
+
+  const { patientId } = req.params;
+  const { from, to, doctor, department } = req.query;
+
+  let query = supabase
+    .from("encounters")
+    .select(
+      "id, encounter_date, doctor, department, notes, diagnoses(id, description), prescriptions(id, medication, dosage, instructions)"
+    )
+    .eq("patient_id", patientId)
+    .order("encounter_date", { ascending: false });
+
+  if (from) query = query.gte("encounter_date", from);
+  if (to) query = query.lte("encounter_date", to);
+  if (doctor) query = query.eq("doctor", doctor);
+  if (department) query = query.eq("department", department);
+
+  const { data, error } = await query;
+  if (error) {
+    res.status(500).json({ error: error.message });
+    return;
+  }
+
+  res.json(data);
+});
+
+router.post("/", async (req, res) => {
+  const user = await ensureStaff(req, res);
+  if (!user) return;
+
+  const { encounter, diagnoses, prescriptions } = req.body;
+  const { data, error } = await supabase
+    .from("encounters")
+    .insert(encounter)
+    .select("id")
+    .single();
+
+  if (error) {
+    res.status(500).json({ error: error.message });
+    return;
+  }
+
+  const encounterId = data.id;
+  if (diagnoses && diagnoses.length) {
+    await supabase
+      .from("diagnoses")
+      .insert(diagnoses.map((d: any) => ({ ...d, encounter_id: encounterId })));
+  }
+  if (prescriptions && prescriptions.length) {
+    await supabase
+      .from("prescriptions")
+      .insert(
+        prescriptions.map((p: any) => ({ ...p, encounter_id: encounterId })),
+      );
+  }
+
+  res.status(201).json({ id: encounterId });
+});
+
+export default router;

--- a/src/components/dashboard/DoctorView.tsx
+++ b/src/components/dashboard/DoctorView.tsx
@@ -50,7 +50,12 @@ const DoctorView = () => {
         )}
       </div>
       <div className="w-full md:w-[350px] border-t md:border-t-0 md:border-l bg-gray-50 p-4 overflow-y-auto order-3">
-        {currentPatient && <PatientHistory patientName={currentPatient.name} />}
+        {currentPatient && (
+          <PatientHistory
+            patientId={currentPatient.id}
+            patientName={currentPatient.name}
+          />
+        )}
       </div>
     </div>
   );

--- a/supabase/migrations/20240610000000_create_patient_history.sql
+++ b/supabase/migrations/20240610000000_create_patient_history.sql
@@ -1,0 +1,35 @@
+create table if not exists public.encounters (
+  id uuid primary key default gen_random_uuid(),
+  patient_id uuid not null references patients(id) on delete cascade,
+  doctor text not null,
+  department text not null,
+  encounter_date date not null default current_date,
+  notes text
+);
+
+create table if not exists public.diagnoses (
+  id uuid primary key default gen_random_uuid(),
+  encounter_id uuid not null references public.encounters(id) on delete cascade,
+  description text not null
+);
+
+create table if not exists public.prescriptions (
+  id uuid primary key default gen_random_uuid(),
+  encounter_id uuid not null references public.encounters(id) on delete cascade,
+  medication text not null,
+  dosage text,
+  instructions text
+);
+
+alter table public.encounters enable row level security;
+alter table public.diagnoses enable row level security;
+alter table public.prescriptions enable row level security;
+
+create policy "staff_access" on public.encounters
+  for all using (auth.jwt() ->> 'role' = 'staff');
+
+create policy "staff_access" on public.diagnoses
+  for all using (auth.jwt() ->> 'role' = 'staff');
+
+create policy "staff_access" on public.prescriptions
+  for all using (auth.jwt() ->> 'role' = 'staff');


### PR DESCRIPTION
## Summary
- create encounters, diagnoses, and prescriptions tables with RLS
- add Express API for patient history secured for staff
- fetch and filter patient history in dashboard

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890fbfffc988326b18a17307aa4ebcb